### PR TITLE
Renaming libps2sdkc to libcglue

### DIFF
--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -4,7 +4,7 @@
     --start-group \
         %{g:-lg} %{!g:-lc} \
         -lcdvd \
-        -lps2sdkc \
+        -lcglue \
         -lkernel \
     --end-group"
 


### PR DESCRIPTION
## Description 
This PR is part of a collection, where we have renamed the `libps2sdkc` to a more appropriate name `libcglue`

All the related PRs are:
- [gcc](https://github.com/ps2dev/gcc/pull/1)
- [newlib](https://github.com/ps2dev/newlib/pull/4)
- [ps2sdk](https://github.com/ps2dev/ps2sdk/pull/279)
- [ps2dev](https://github.com/ps2dev/ps2dev/pull/52)

The CI/CD is currently failing because it requires a proper merging process.

The merging process should be:
1. Merge `gcc`
2. Merge `newlib`
3. Trigger a new CI/CD in `ps2toolchain`
4. Merge `ps2sdk`
5. Merge `ps2dev`