### PR TITLE
Adding `std::thread` support

### DIFF
--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -4,6 +4,8 @@
     --start-group \
         %{g:-lg} %{!g:-lc} \
         -lcdvd \
+        -lpthread \
+        -lpthreadglue \
         -lcglue \
         -lkernel \
     --end-group"

--- a/libgcc/gthr.h
+++ b/libgcc/gthr.h
@@ -144,6 +144,17 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #ifndef GTHREAD_USE_WEAK
 #define GTHREAD_USE_WEAK 1
 #endif
+
+/* *** PS2 Specific change for std::thread ***
+   This file is modified by running sed commands on the 
+   libstdc++-v3/include/Makefile.am
+   These sed commands add prefix to the existing macros
+   this is why we CAN'T add here an #if __PS2__
+   As solution we force here GTHREAD_USE_WEAK to be 0 
+*/
+#undef GTHREAD_USE_WEAK
+#define GTHREAD_USE_WEAK 0
+
 #endif
 #include "gthr-default.h"
 


### PR DESCRIPTION
This PR is part of a collection for the std::tread support in the PS2 EE Toolchain

It basically does:

Add `libpthread.a`, `libpthreadglue.a` as part of the standard libraries
GCC looks to have a bug with `GTHREAD_USE_WEAK` so we are forcing it to be disabled.

More info about the `GCC` bug here: https://github.com/pspdev/gcc/pull/2