### PR TITLE
Rebase ee patches on gcc14

### DIFF
--- a/gcc/config.gcc
+++ b/gcc/config.gcc
@@ -2773,7 +2773,7 @@ mips-*-elf* | mipsel-*-elf* | mipsr5900-*-elf* | mipsr5900el-*-elf*)
 	tmake_file="mips/t-elf"
 	;;
 mips64r5900-*-elf* | mips64r5900el-*-elf*)
-	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h"
+	tm_file="elfos.h newlib-stdint.h ${tm_file} mips/elf.h mips/n32-elf.h mips/ps2sdk.h"
 	tmake_file="mips/t-elf"
 	tm_defines="${tm_defines} MIPS_ISA_DEFAULT=MIPS_ISA_MIPS3 MIPS_ABI_DEFAULT=ABI_N32"
 	;;

--- a/gcc/config/mips/5900.md
+++ b/gcc/config/mips/5900.md
@@ -18,6 +18,99 @@
 ;;
 ;; R5900 instruction patterns and pipeline tuning.
 
+(define_automaton "r5900_alu,r5900_mac,r5900_fpu,r5900_br,r5900_ls")
+
+(define_cpu_unit "r5900_alu0,r5900_alu1" "r5900_alu")
+(define_cpu_unit "r5900_mac" "r5900_mac")
+(define_cpu_unit "r5900_c1" "r5900_fpu")
+(define_cpu_unit "r5900_br" "r5900_br")
+(define_cpu_unit "r5900_ls" "r5900_ls")
+
+(define_insn_reservation "r5900_alu" 1
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "unknown,prefetch,prefetchx,condmove,const,arith,
+			shift,slt,clz,trap,multi,nop,logical,signext,move"))
+ "r5900_alu0|r5900_alu1")
+
+(define_insn_reservation "r5900_loadstore" 1
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "load,store"))
+ "r5900_ls")
+
+(define_insn_reservation "r5900_fploadstore" 2
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "fpload,fpstore"))
+ "r5900_c1*2")
+
+(define_insn_reservation "r5900_fcvt" 4
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "fcvt"))
+ "r5900_c1*4")
+
+(define_insn_reservation "r5900_fmove" 4
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "fabs,fneg,fmove"))
+ "r5900_c1*4")
+
+(define_insn_reservation "r5900_fcmp" 4
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "fcmp"))
+ "r5900_c1*4")
+
+(define_insn_reservation "r5900_fadd" 4
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "fadd"))
+ "r5900_c1*4")
+
+(define_insn_reservation "r5900_fmul_single" 4
+  (and (eq_attr "cpu" "r5900")
+       (and (eq_attr "type" "fmul,fmadd")
+            (eq_attr "mode" "SF")))
+ "r5900_c1*4")
+
+(define_insn_reservation "r5900_fdiv_single" 8
+  (and (eq_attr "cpu" "r5900")
+       (and (eq_attr "type" "fdiv,frdiv")
+            (eq_attr "mode" "SF")))
+ "r5900_c1*8")
+
+(define_insn_reservation "r5900_fsqrt_single" 8
+  (and (eq_attr "cpu" "r5900")
+       (and (eq_attr "type" "fsqrt")
+            (eq_attr "mode" "SF")))
+ "r5900_c1*8")
+
+(define_insn_reservation "r5900_frsqrt_single" 15
+  (and (eq_attr "cpu" "r5900")
+       (and (eq_attr "type" "frsqrt")
+            (eq_attr "mode" "SF")))
+ "r5900_c1*14")
+
+(define_insn_reservation "r5900_xfer" 2
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "mfc,mtc"))
+ "r5900_alu0|r5900_alu1")
+
+(define_insn_reservation "r5900_branch" 1
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "branch,jump,call"))
+ "r5900_br")
+
+(define_insn_reservation "r5900_hilo" 1
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "mfhi,mflo,mthi,mtlo"))
+ "r5900_mac")
+
+(define_insn_reservation "r5900_imul" 4
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "imul,imul3,imadd"))
+ "r5900_mac*4")
+
+(define_insn_reservation "r5900_idiv" 37
+  (and (eq_attr "cpu" "r5900")
+       (eq_attr "type" "idiv,idiv3"))
+ "r5900_mac*37")
+
 ;; RSQRT
 (define_insn "rsqrtsf"
   [(set (match_operand:SF 0 "register_operand" "=f")

--- a/gcc/config/mips/5900.md
+++ b/gcc/config/mips/5900.md
@@ -1,0 +1,48 @@
+;; Copyright (C) 2002-2015 Free Software Foundation, Inc.
+;;
+;; This file is part of GCC.
+;;
+;; GCC is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+;;
+;; GCC is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with GCC; see the file COPYING3.  If not see
+;; <http://www.gnu.org/licenses/>.
+;;
+;; R5900 instruction patterns and pipeline tuning.
+
+;; RSQRT
+(define_insn "rsqrtsf"
+  [(set (match_operand:SF 0 "register_operand" "=f")
+	(div:SF (match_operand:SF 1 "register_operand" "f")
+		  (sqrt:SF (match_operand:SF 2 "register_operand" "f"))))]
+  "TARGET_MIPS5900"
+  "rsqrt.s\t%0,%1,%2"
+  [(set_attr "type" "frsqrt")
+   (set_attr "mode" "SF")])
+
+;; MIN and MAX
+(define_insn "sminsf3"
+  [(set (match_operand:SF 0 "register_operand" "=f")
+	(smin:SF (match_operand:SF 1 "register_operand" "f")
+		 (match_operand:SF 2 "register_operand" "f")))]
+  "TARGET_MIPS5900"
+  "min.s\t%0,%1,%2"
+  [(set_attr "type" "fadd")
+   (set_attr "mode" "SF")])
+
+(define_insn "smaxsf3"
+  [(set (match_operand:SF 0 "register_operand" "=f")
+	(smax:SF (match_operand:SF 1 "register_operand" "f")
+		 (match_operand:SF 2 "register_operand" "f")))]
+  "TARGET_MIPS5900"
+  "max.s\t%0,%1,%2"
+  [(set_attr "type" "fadd")
+   (set_attr "mode" "SF")])

--- a/gcc/config/mips/5900.md
+++ b/gcc/config/mips/5900.md
@@ -18,10 +18,9 @@
 ;;
 ;; R5900 instruction patterns and pipeline tuning.
 
-(define_automaton "r5900_alu,r5900_mac,r5900_fpu,r5900_br,r5900_ls")
+(define_automaton "r5900_alu,r5900_fpu,r5900_br,r5900_ls")
 
 (define_cpu_unit "r5900_alu0,r5900_alu1" "r5900_alu")
-(define_cpu_unit "r5900_mac" "r5900_mac")
 (define_cpu_unit "r5900_c1" "r5900_fpu")
 (define_cpu_unit "r5900_br" "r5900_br")
 (define_cpu_unit "r5900_ls" "r5900_ls")
@@ -40,56 +39,56 @@
 (define_insn_reservation "r5900_fploadstore" 2
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "fpload,fpstore"))
- "r5900_c1*2")
+ "r5900_c1,nothing")
 
 (define_insn_reservation "r5900_fcvt" 4
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "fcvt"))
- "r5900_c1*4")
+ "r5900_c1,nothing*3")
 
 (define_insn_reservation "r5900_fmove" 4
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "fabs,fneg,fmove"))
- "r5900_c1*4")
+ "r5900_c1,nothing*3")
 
 (define_insn_reservation "r5900_fcmp" 4
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "fcmp"))
- "r5900_c1*4")
+ "r5900_c1,nothing*3")
 
 (define_insn_reservation "r5900_fadd" 4
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "fadd"))
- "r5900_c1*4")
+ "r5900_c1,nothing*3")
 
 (define_insn_reservation "r5900_fmul_single" 4
   (and (eq_attr "cpu" "r5900")
        (and (eq_attr "type" "fmul,fmadd")
             (eq_attr "mode" "SF")))
- "r5900_c1*4")
+ "r5900_c1,nothing*3")
 
 (define_insn_reservation "r5900_fdiv_single" 8
   (and (eq_attr "cpu" "r5900")
        (and (eq_attr "type" "fdiv,frdiv")
             (eq_attr "mode" "SF")))
- "r5900_c1*8")
+ "r5900_c1*7,nothing")
 
 (define_insn_reservation "r5900_fsqrt_single" 8
   (and (eq_attr "cpu" "r5900")
        (and (eq_attr "type" "fsqrt")
             (eq_attr "mode" "SF")))
- "r5900_c1*8")
+ "r5900_c1*7,nothing")
 
-(define_insn_reservation "r5900_frsqrt_single" 15
+(define_insn_reservation "r5900_frsqrt_single" 14
   (and (eq_attr "cpu" "r5900")
        (and (eq_attr "type" "frsqrt")
             (eq_attr "mode" "SF")))
- "r5900_c1*14")
+ "r5900_c1*13,nothing")
 
 (define_insn_reservation "r5900_xfer" 2
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "mfc,mtc"))
- "r5900_alu0|r5900_alu1")
+ "r5900_c1+r5900_ls,nothing")
 
 (define_insn_reservation "r5900_branch" 1
   (and (eq_attr "cpu" "r5900")
@@ -99,17 +98,17 @@
 (define_insn_reservation "r5900_hilo" 1
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "mfhi,mflo,mthi,mtlo"))
- "r5900_mac")
+ "r5900_alu0")
 
 (define_insn_reservation "r5900_imul" 4
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "imul,imul3,imadd"))
- "r5900_mac*4")
+ "r5900_alu0*2,nothing*2")
 
 (define_insn_reservation "r5900_idiv" 37
   (and (eq_attr "cpu" "r5900")
        (eq_attr "type" "idiv,idiv3"))
- "r5900_mac*37")
+ "r5900_alu0*37")
 
 ;; RSQRT
 (define_insn "rsqrtsf"

--- a/gcc/config/mips/mips.cc
+++ b/gcc/config/mips/mips.cc
@@ -20401,6 +20401,11 @@ mips_option_override (void)
     error ("unsupported combination: %s",
 	   "-march=r5900 -mhard-float -mdouble-float");
 
+  /* The R5900 does not support some MIPS16 instructions.  */
+  if (TARGET_MIPS5900 && ((mips_base_compression_flags & MASK_MIPS16) != 0))
+	  error("unsupported combination: %s",
+		  "-march=r5900 -mips16");
+
   /* If a -mlong* option was given, check that it matches the ABI,
      otherwise infer the -mlong* setting from the other options.  */
   if ((target_flags_explicit & MASK_LONG64) != 0)

--- a/gcc/config/mips/mips.h
+++ b/gcc/config/mips/mips.h
@@ -1199,7 +1199,7 @@ struct mips_cpu_info {
 #define ISA_HAS_IEEE_754_2008	(mips_isa_rev >= 2)
 
 /* ISA has count leading zeroes/ones instruction (not implemented).  */
-#define ISA_HAS_CLZ_CLO		(mips_isa_rev >= 1 && !TARGET_MIPS16)
+#define ISA_HAS_CLZ_CLO		(mips_isa_rev >= 1 && !TARGET_MIPS16 && !TARGET_MIPS5900)
 
 /* ISA has count trailing zeroes/ones instruction.  */
 #define ISA_HAS_CTZ_CTO		(TARGET_LOONGSON_EXT2)

--- a/gcc/config/mips/mips.md
+++ b/gcc/config/mips/mips.md
@@ -1105,6 +1105,7 @@
 
 (define_delay (and (eq_attr "type" "branch")
 		   (not (match_test "TARGET_MIPS16"))
+		   (not (match_test "TARGET_FIX_R5900"))
 		   (eq_attr "branch_likely" "yes"))
   [(eq_attr "can_delay" "yes")
    (nil)
@@ -1114,6 +1115,7 @@
 ;; not annul on false.
 (define_delay (and (eq_attr "type" "branch,simd_branch")
 		   (not (match_test "TARGET_MIPS16"))
+		   (not (match_test "TARGET_FIX_R5900"))
 		   (ior (match_test "TARGET_CB_NEVER")
 			(and (eq_attr "compact_form" "maybe")
 			     (not (match_test "TARGET_CB_ALWAYS")))

--- a/gcc/config/mips/mips.md
+++ b/gcc/config/mips/mips.md
@@ -1184,6 +1184,7 @@
 (include "5000.md")
 (include "5400.md")
 (include "5500.md")
+(include "5900.md")
 (include "6000.md")
 (include "7000.md")
 (include "9000.md")

--- a/gcc/config/mips/mips.md
+++ b/gcc/config/mips/mips.md
@@ -1796,7 +1796,7 @@
 		 (match_operand:SI 3 "register_operand" "l,l,l,d")))
    (clobber (match_scratch:SI 4 "=X,X,3,l"))
    (clobber (match_scratch:SI 5 "=X,X,X,&d"))]
-  "TARGET_MIPS3900 && !TARGET_MIPS16"
+  "(TARGET_MIPS3900 || TARGET_MIPS5900) && !TARGET_MIPS16"
   "@
     madd\t%1,%2
     madd\t%1,%2

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -1,0 +1,9 @@
+#undef  LIB_SPEC
+#define LIB_SPEC "\
+    -lm \
+    --start-group \
+        %{g:-lg} %{!g:-lc} \
+        -lcdvd \
+        -lps2sdkc \
+        -lkernel \
+    --end-group"

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -7,3 +7,9 @@
         -lps2sdkc \
         -lkernel \
     --end-group"
+
+#undef STARTFILE_SPEC
+#define STARTFILE_SPEC "crt0.o%s crti.o%s crtbegin.o%s"
+
+#undef ENDFILE_SPEC
+#define ENDFILE_SPEC "crtend.o%s crtn.o%s"

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -4,7 +4,7 @@
     --start-group \
         %{g:-lg} %{!g:-lc} \
         -lcdvd \
-        -lps2sdkc \
+        -lcglue \
         -lkernel \
     --end-group"
 

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -15,3 +15,37 @@
 
 #undef ENDFILE_SPEC
 #define ENDFILE_SPEC "crtend.o%s crtn.o%s"
+
+/* The following definitions are for shared object support. */
+/* Reference: gcc/config/mips/mips.h, gcc/config/mips/gnu-user.h */
+
+/* If we don't set MASK_ABICALLS, we can't allow usage of PIC.  */
+#undef TARGET_DEFAULT
+#define TARGET_DEFAULT MASK_ABICALLS
+
+/* -G is incompatible with -mabicalls which is the default, so only allow
+   objects in the small data section if the user explicitly asks for it.  */
+#undef MIPS_DEFAULT_GVALUE
+#define MIPS_DEFAULT_GVALUE 0
+
+/* Conditionally enable PIC depending on the presence of -mplt.  */
+#undef SUBTARGET_ASM_SPEC
+#define SUBTARGET_ASM_SPEC \
+  "%{!mno-abicalls:%{mplt:-call_nonpic;:-KPIC}}"
+
+/* Set some default options for the driver. Mainly, this optimizes default
+   options for executables and allows usage of shared objects if requested. */
+#define PS2SDK_DRIVER_SELF_SPECS \
+  "%{mshared|mno-shared:;:%{" FPIE_OR_FPIC_SPEC ":-mshared;:-mno-shared}}",             \
+  "%{mplt|mno-plt:;:-mplt}",             \
+  /* -mplt has no effect without -mno-shared.  Simplify later   \
+     specs handling by removing a redundant option.  */     \
+  "%{!mno-shared:%<mplt}",            \
+  /* -mplt likewise has no effect for -mabi=64 without -msym32.  */ \
+  "%{mabi=64:%{!msym32:%<mplt}}"
+
+#undef DRIVER_SELF_SPECS
+#define DRIVER_SELF_SPECS \
+  MIPS_ISA_LEVEL_SPEC,    \
+  BASE_DRIVER_SELF_SPECS, \
+  PS2SDK_DRIVER_SELF_SPECS

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -4,6 +4,8 @@
     --start-group \
         %{g:-lg} %{!g:-lc} \
         -lcdvd \
+        -lpthread \
+        -lpthreadglue \
         -lcglue \
         -lkernel \
     --end-group"

--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -16,6 +16,11 @@
 #undef ENDFILE_SPEC
 #define ENDFILE_SPEC "crtend.o%s crtn.o%s"
 
+#define TARGET_OS_CPP_BUILTINS()	\
+do {					\
+  builtin_define ("__ps2sdk__");		\
+} while (0)
+
 /* The following definitions are for shared object support. */
 /* Reference: gcc/config/mips/mips.h, gcc/config/mips/gnu-user.h */
 

--- a/include/longlong.h
+++ b/include/longlong.h
@@ -857,6 +857,17 @@ extern UDItype __umulsidi3 (USItype, USItype);
 #endif
 
 #if defined (__mips__) && W_TYPE_SIZE == 32
+/* Force R5900 to use mult for mulsidi3, this is used in muldi3 */
+#ifdef _MIPS_ARCH_R5900
+#define __umulsidi3(u, v) \
+  ({UDItype __w;							\
+    __asm__ ("multu	%1,%2\n\tpmfhl.lw %0"				\
+	     : "=d" (__w)						\
+	     : "d" ((USItype) (u)),					\
+	       "d" ((USItype) (v))					\
+	     : "hi", "lo");						\
+    __w; })
+#endif
 #define umul_ppmm(w1, w0, u, v)						\
   do {									\
     UDItype __x = (UDItype) (USItype) (u) * (USItype) (v);		\

--- a/include/longlong.h
+++ b/include/longlong.h
@@ -877,7 +877,7 @@ extern UDItype __umulsidi3 (USItype, USItype);
 #define UMUL_TIME 10
 #define UDIV_TIME 100
 
-#if (__mips == 32 || __mips == 64) && ! defined (__mips16)
+#if (__mips == 32 || __mips == 64) && !defined (__mips16) && !defined(_MIPS_ARCH_R5900)
 #define count_leading_zeros(COUNT,X)	((COUNT) = __builtin_clz (X))
 #define COUNT_LEADING_ZEROS_0 32
 #endif

--- a/libgcc/config.host
+++ b/libgcc/config.host
@@ -165,7 +165,11 @@ mips*-*-*)
 	cpu_type=mips
 	tmake_file="mips/t-mips"
 	if test "${libgcc_cv_mips_hard_float}" = yes; then
+	    if test "${libgcc_cv_mips_single_float}" = yes; then
+                tmake_file="${tmake_file} t-hardfp-sf t-hardfp"
+	    else
 		tmake_file="${tmake_file} t-hardfp-sfdf t-hardfp"
+	    fi
 	else
 		tmake_file="${tmake_file} t-softfp-sfdf"
 	fi
@@ -1051,19 +1055,16 @@ mips*-*-netbsd*)			# NetBSD/mips, either endian.
 mips*-*-linux*)				# Linux MIPS, either endian.
 	extra_parts="$extra_parts crtfastmath.o"
 	tmake_file="${tmake_file} t-crtfm"
-	case ${host} in
-	  mips64r5900* | mipsr5900*)
-	    # The MIPS16 support code uses floating point
-	    # instructions that are not supported on r5900.
-	    ;;
-	  *)
+    if test "${libgcc_cv_mips16}" = yes; then
 	    tmake_file="${tmake_file} mips/t-mips16 t-slibgcc-libgcc"
-	    ;;
-	esac
+    fi
 	md_unwind_header=mips/linux-unwind.h
 	;;
 mips*-sde-elf*)
-	tmake_file="$tmake_file mips/t-crtstuff mips/t-mips16"
+	tmake_file="$tmake_file mips/t-crtstuff"
+    if test "${libgcc_cv_mips16}" = yes; then
+	  tmake_file="${tmake_file} mips/t-mips16"
+    fi
 	case "${with_newlib}" in
 	  yes)
 	    # newlib / libgloss.
@@ -1093,7 +1094,10 @@ mipsisa64sb1-*-elf* | mipsisa64sb1el-*-elf*)
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mips-*-elf* | mipsel-*-elf*)
-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
+	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
+    if test "${libgcc_cv_mips16}" = yes; then
+	  tmake_file="${tmake_file} mips/t-mips16"
+    fi
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mipsr5900-*-elf* | mipsr5900el-*-elf*)
@@ -1101,7 +1105,10 @@ mipsr5900-*-elf* | mipsr5900el-*-elf*)
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mips64-*-elf* | mips64el-*-elf*)
-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
+	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
+    if test "${libgcc_cv_mips16}" = yes; then
+	  tmake_file="${tmake_file} mips/t-mips16"
+    fi
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mips64r5900-*-elf* | mips64r5900el-*-elf*)
@@ -1117,7 +1124,10 @@ mips64orion-*-elf* | mips64orionel-*-elf*)
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mips*-*-rtems*)
-	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff mips/t-mips16"
+	tmake_file="$tmake_file mips/t-elf mips/t-crtstuff"
+    if test "${libgcc_cv_mips16}" = yes; then
+	  tmake_file="${tmake_file} mips/t-mips16"
+    fi
 	extra_parts="$extra_parts crti.o crtn.o"
 	;;
 mips-wrs-vxworks)

--- a/libgcc/config/mips/sfp-machine.h
+++ b/libgcc/config/mips/sfp-machine.h
@@ -22,7 +22,7 @@ a copy of the GCC Runtime Library Exception along with this program;
 see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 <http://www.gnu.org/licenses/>.  */
 
-#ifdef __mips64
+#if defined(__mips64) && !defined(_MIPS_ARCH_R5900)
 #define _FP_W_TYPE_SIZE		64
 #define _FP_W_TYPE		unsigned long long
 #define _FP_WS_TYPE		signed long long

--- a/libgcc/config/t-hardfp-sf
+++ b/libgcc/config/t-hardfp-sf
@@ -1,0 +1,32 @@
+# Copyright (C) 2014-2015 Free Software Foundation, Inc.
+
+# This file is part of GCC.
+
+# GCC is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 3, or (at your option)
+# any later version.
+
+# GCC is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+
+# You should have received a copy of the GNU General Public License
+# along with GCC; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+hardfp_float_modes := sf
+# di and ti are provided by libgcc2.c where needed.
+hardfp_int_modes := si
+hardfp_extensions :=
+hardfp_truncations :=
+
+# Emulate 64 bit float:
+FPBIT = true
+DPBIT = true
+# Don't build functions handled by 32 bit hardware:
+LIB2FUNCS_EXCLUDE = _addsub_sf _mul_sf _div_sf \
+    _fpcmp_parts_sf _compare_sf _eq_sf _ne_sf _gt_sf _ge_sf \
+    _lt_sf _le_sf _unord_sf _si_to_sf _sf_to_si _negate_sf \
+    _thenan_sf _sf_to_usi _usi_to_sf

--- a/libgcc/configure
+++ b/libgcc/configure
@@ -5108,6 +5108,48 @@ rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
 fi
 { $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_hard_float" >&5
 $as_echo "$libgcc_cv_mips_hard_float" >&6; }
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target is single-float" >&5
+$as_echo_n "checking whether the target is single-float... " >&6; }
+if test "${libgcc_cv_mips_single_float+set}" = set; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+#ifndef __mips_single_float
+     #error FOO
+     #endif
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  libgcc_cv_mips_single_float=yes
+else
+  libgcc_cv_mips_single_float=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips_single_float" >&5
+$as_echo "$libgcc_cv_mips_single_float" >&6; }
+  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking whether the target supports the MIPS16 ASE" >&5
+$as_echo_n "checking whether the target supports MIPS16 ASE... " >&6; }
+if test "${libgcc_cv_mips16+set}" = set; then :
+  $as_echo_n "(cached) " >&6
+else
+  CFLAGS_hold=$CFLAGS
+		 CFLAGS="$CFLAGS -mips16"
+		 cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+int i;
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  libgcc_cv_mips16=yes
+else
+  libgcc_cv_mips16=no
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+	CFLAGS=$CFLAGS_hold
+fi
+{ $as_echo "$as_me:${as_lineno-$LINENO}: result: $libgcc_cv_mips16" >&5
+$as_echo "$libgcc_cv_mips16" >&6; }
 esac
 
 case ${host} in

--- a/libgcc/configure.ac
+++ b/libgcc/configure.ac
@@ -344,6 +344,23 @@ mips*-*-*)
     ])],
     [libgcc_cv_mips_hard_float=yes],
     [libgcc_cv_mips_hard_float=no])])
+  AC_CACHE_CHECK([whether the target is single-float],
+		 [libgcc_cv_mips_single_float],
+		 [AC_COMPILE_IFELSE(
+    [#ifndef __mips_single_float
+     #error FOO
+     #endif],
+    [libgcc_cv_mips_single_float=yes],
+    [libgcc_cv_mips_single_float=no])])
+  # Some targets (i.e. R5900) don't support some MIPS16 instructions.
+  AC_CACHE_CHECK([whether the target supports the MIPS16 ASE],
+		 [libgcc_cv_mips16],
+		 [CFLAGS_hold=$CFLAGS
+		 CFLAGS="$CFLAGS -mips16"
+		 AC_COMPILE_IFELSE([[int i;]],
+    [libgcc_cv_mips16=yes],
+    [libgcc_cv_mips16=no])
+	CFLAGS=$CFLAGS_hold])
 esac
 
 case ${host} in

--- a/libgcc/gthr.h
+++ b/libgcc/gthr.h
@@ -153,6 +153,17 @@ see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
 #ifndef GTHREAD_USE_WEAK
 #define GTHREAD_USE_WEAK 1
 #endif
+
+/* *** PS2 Specific change for std::thread ***
+   This file is modified by running sed commands on the 
+   libstdc++-v3/include/Makefile.am
+   These sed commands add prefix to the existing macros
+   this is why we CAN'T add here an #if __PS2__
+   As solution we force here GTHREAD_USE_WEAK to be 0 
+*/
+#undef GTHREAD_USE_WEAK
+#define GTHREAD_USE_WEAK 0
+
 #endif
 #include "gthr-default.h"
 


### PR DESCRIPTION
This also adds a builtin \_\_ps2sdk\_\_ platform define which is used to fix a newlib build error. (see https://github.com/ps2dev/newlib/pull/14)