### PR TITLE
Adding profglue library to standards

### DIFF
--- a/gcc/config/mips/ps2sdk.h
+++ b/gcc/config/mips/ps2sdk.h
@@ -3,6 +3,7 @@
     -lm \
     --start-group \
         %{g:-lg} %{!g:-lc} \
+        %{pg:-lprofglue} \
         -lcdvd \
         -lpthread \
         -lpthreadglue \


### PR DESCRIPTION
## Description
This PR basically adds the library `libprofglue.a` to standards when linking with the flag `-pg`