### PR TITLE
xgcc selftest makeopts

### DIFF
--- a/gcc/Makefile.in
+++ b/gcc/Makefile.in
@@ -2214,7 +2214,7 @@ SELFTEST_FLAGS = -nostdinc $(DEVNULL) -S -o $(DEVNULL) \
 # s-selftest-<LANG>.  Otherwise, they should define it as empty.
 
 SELFTEST_TARGETS = @selftest_languages@
-selftest: $(SELFTEST_TARGETS)
+selftest: $(SELFTEST_TARGETS) xgcc$(exeext)
 
 # Recompile all the language-independent object files.
 # This is used only if the user explicitly asks for it.


### PR DESCRIPTION
Fixes build-mips64r5900el-ps2-elf-stage2/./gcc/xgcc: No such file or directory on MINGW build by using a patch from  [gcc-10.1.0-xgcc-selftest-makeopts.patch](https://gcc.gnu.org/bugzilla/attachment.cgi?id=48861&action=diff)